### PR TITLE
Make firstDayOfWeek and lastDayOfWeek locale specific

### DIFF
--- a/AF+Date+Helper/AF+Date+Extension.swift
+++ b/AF+Date+Helper/AF+Date+Extension.swift
@@ -267,7 +267,7 @@ extension NSDate {
     {
         let flags :NSCalendarUnit = NSCalendarUnit.CalendarUnitYear | NSCalendarUnit.CalendarUnitMonth | NSCalendarUnit.CalendarUnitWeekOfYear | NSCalendarUnit.CalendarUnitWeekday
         var components = NSCalendar.currentCalendar().components(flags, fromDate: self)
-        components.weekday = 1 // Sunday
+        components.weekday = NSCalendar.currentCalendar().firstWeekday
         components.hour = 0
         components.minute = 0
         components.second = 0
@@ -278,7 +278,7 @@ extension NSDate {
     {
         let flags :NSCalendarUnit = NSCalendarUnit.CalendarUnitYear | NSCalendarUnit.CalendarUnitMonth | NSCalendarUnit.CalendarUnitWeekOfYear | NSCalendarUnit.CalendarUnitWeekday
         var components = NSCalendar.currentCalendar().components(flags, fromDate: self)
-        components.weekday = 7 // Sunday
+        components.weekday = NSCalendar.currentCalendar().firstWeekday + 7
         components.hour = 0
         components.minute = 0
         components.second = 0


### PR DESCRIPTION
Currently Sunday is hard coded as the first day of the week, which is not the case in all locales. For example in Sweden Monday is considered the first day of the week. 

This should fix that. However, I'm not as sure about `NSCalendar.currentCalendar().firstWeekday + 7` if that works as intended. I could not find a `lastWeekday` so I went with `+ 7` which seems to work.