### PR TITLE
Fixed Carthage build

### DIFF
--- a/AFDateHelper.xcodeproj/project.pbxproj
+++ b/AFDateHelper.xcodeproj/project.pbxproj
@@ -105,7 +105,7 @@
 				65B7EA75197082AA0097E598 /* README.md */,
 				6524A6281D065F8D00BC7D4D /* AppDemo */,
 				63B7E9B41CF6DCFE00E9D8EF /* AppleTVDemo */,
-				CD1B226B1CB62C8400992308 /* Feamework */,
+				CD1B226B1CB62C8400992308 /* Framework */,
 				655AEB41192D42990053AD6C /* Frameworks */,
 				655AEB40192D42990053AD6C /* Products */,
 			);
@@ -140,13 +140,13 @@
 			path = AFDateHelper;
 			sourceTree = "<group>";
 		};
-		CD1B226B1CB62C8400992308 /* Feamework */ = {
+		CD1B226B1CB62C8400992308 /* Framework */ = {
 			isa = PBXGroup;
 			children = (
 				CD1B226C1CB62C8400992308 /* AFDateHelper.h */,
 				CD1B226E1CB62C8400992308 /* Info.plist */,
 			);
-			name = Feamework;
+			name = Framework;
 			path = AFDateHelper;
 			sourceTree = "<group>";
 		};

--- a/AFDateHelper.xcodeproj/project.pbxproj
+++ b/AFDateHelper.xcodeproj/project.pbxproj
@@ -505,7 +505,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				GCC_NO_COMMON_BLOCKS = YES;
-				INFOPLIST_FILE = AFDateHelper/Info.plist;
+				INFOPLIST_FILE = "$(SRCROOT)/Framework/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
@@ -534,7 +534,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				GCC_NO_COMMON_BLOCKS = YES;
-				INFOPLIST_FILE = AFDateHelper/Info.plist;
+				INFOPLIST_FILE = "$(SRCROOT)/Framework/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";


### PR DESCRIPTION
Since the last code restructure the carthage build failed, because the info.plist was missing for the framework target. This should be fixed now. I also fixed a little typo in the Xcode folder name.